### PR TITLE
Add production build flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web3d
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web3d
+  template:
+    metadata:
+      labels:
+        app: web3d
+    spec:
+      containers:
+        - name: web3d
+          image: web3d:latest
+          ports:
+            - containerPort: 80

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "npx vite"
+    "dev": "npx vite",
+    "build": "vite build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a `build` script using vite
- create production Dockerfile using multi-stage build and nginx
- provide K8s deployment manifest that runs on port 80

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861181a051c832d85060f2f34fdddac