### PR TITLE
Add URL replacement script with dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Web3D
+
+This project uses environment variables to configure where some links lead.
+
+## Changing URLs
+
+1. Edit the `.env` file in the project root and update any of the following values:
+   - `AYON_URL`
+   - `ZULIP_URL`
+   - `SPACE_URL`
+   - `TASKS_URL`
+2. Run the build process:
+
+```bash
+npm run build
+```
+
+During `npm run build` the script `scripts/replaceUrls.js` will run automatically and update the references in the `src/main.js` and `src/main2.js` files using the values from `.env`.
+
+After the build completes, the application will use the updated URLs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dat.gui": "^0.7.9",
+        "dotenv": "^17.0.0",
         "gsap": "^3.12.7",
         "three": "^0.173.0",
         "three-orbitcontrols": "^2.110.2"
@@ -1879,6 +1880,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
+      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "npx vite",
+    "prebuild": "node scripts/replaceUrls.js",
     "build": "vite build"
   },
   "keywords": [],
@@ -12,6 +13,7 @@
   "description": "",
   "dependencies": {
     "dat.gui": "^0.7.9",
+    "dotenv": "^17.0.0",
     "gsap": "^3.12.7",
     "three": "^0.173.0",
     "three-orbitcontrols": "^2.110.2"

--- a/scripts/replaceUrls.js
+++ b/scripts/replaceUrls.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const mappings = [
+  {
+    env: 'AYON_URL',
+    file: path.join(__dirname, '..', 'src', 'main.js'),
+    search: /window\.location\.href\s*=\s*"https:\/\/ayon\.d2-india\.com\/";/
+  },
+  {
+    env: 'ZULIP_URL',
+    file: path.join(__dirname, '..', 'src', 'main.js'),
+    search: /window\.location\.href\s*=\s*"http:\/\/zulip\.d2-india\.com\/";/
+  },
+  {
+    env: 'SPACE_URL',
+    file: path.join(__dirname, '..', 'src', 'main.js'),
+    search: /window\.location\.href\s*=\s*"http:\/\/grid\.d2-india\.com";/
+  },
+  {
+    env: 'TASKS_URL',
+    file: path.join(__dirname, '..', 'src', 'main2.js'),
+    search: /window\.location\.href\s*=\s*"http:\/\/localhost:5173\/";/
+  },
+];
+
+for (const { env, file, search } of mappings) {
+  const value = process.env[env];
+  if (!value) continue;
+  if (!fs.existsSync(file)) continue;
+  const content = fs.readFileSync(file, 'utf8');
+  if (search.test(content)) {
+    const replaced = content.replace(search, 'window.location.href = "' + value + '";');
+    fs.writeFileSync(file, replaced, 'utf8');
+    console.log(`Updated ${file} using ${env}`);
+  } else {
+    console.warn(`Pattern for ${env} not found in ${file}`);
+  }
+}


### PR DESCRIPTION
## Summary
- install `dotenv`
- auto-run `scripts/replaceUrls.js` before the build
- ignore `.env` files
- provide simple `.env` driven URL update script
- document how to customise URLs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861197f0afc832d8127b8ef004e6990