### PR TITLE
Add service and ingress manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ npm run build
 During `npm run build` the script `scripts/replaceUrls.js` will run automatically and update the references in the `src/main.js` and `src/main2.js` files using the values from `.env`.
 
 After the build completes, the application will use the updated URLs.
+
+## Kubernetes Deployment
+
+Kubernetes manifests are located in the `k8s/` directory. Apply them in order to deploy the application along with a service and ingress:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+kubectl apply -f k8s/ingress.yaml
+```
+
+The ingress routes requests for `web3d.local` to the `web3d` service. Update the host name as needed for your cluster.

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web3d
+spec:
+  rules:
+    - host: web3d.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web3d
+                port:
+                  number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web3d
+spec:
+  selector:
+    app: web3d
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- add k8s Service to expose the web3d pod
- create a basic Ingress manifest
- document how to apply the manifests

## Testing
- `npm run build` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686506037be0832d84f7a49534aa2f64